### PR TITLE
Failing Test for `brig project create --replace`

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -7,11 +7,19 @@ load "$BATS_TEST_DIRNAME/libs/bats-assert/load.bash"
 
 # Globals
 GIT_DIR="$BATS_TEST_DIRNAME/.."
-BRIG_RUN="$BATS_TEST_DIRNAME/bin/brig run -f $GIT_DIR/brigade.js blimmer/brigade-project-integration-test"
+BRIG_BIN="$BATS_TEST_DIRNAME/bin/brig"
+BRIG_PROJECT_NAME="blimmer/brigade-project-integration-test"
+BRIG_RUN="$BRIG_BIN run -f $GIT_DIR/brigade.js $BRIG_PROJECT_NAME"
 
 # Begin Tests
 
 @test "it can schedule a run" {
   run $BRIG_RUN
+  assert_success
+}
+
+@test "it can replace the project" {
+  # NOTE: the project is already created in the setup scripts
+  run $BRIG_BIN project create -r -x -f "$BATS_TEST_DIRNAME/fixtures/project-fixture.json"
   assert_success
 }


### PR DESCRIPTION
Failing test for https://github.com/Azure/brigade/issues/667

```
 ✓ it can schedule a run
 ✗ it can replace the project
   (from function `assert_success' in file test/libs/bats-assert/src/assert.bash, line 114,
    in test file test/tests.bats, line 24)
     `assert_success' failed

   -- command failed --
   status : 1
   output (20 lines):
     Project ID: brigade-6e35bd4c52f9e015cfe3308c2b19eba59990e1019beb499eadee67
     Error: secrets "brigade-6e35bd4c52f9e015cfe3308c2b19eba59990e1019beb499eadee67" already exists
     Usage:
       brig project create [flags]

     Flags:
       -f, --config string         Path to JSON Kubernetes Secret.
       -D, --dry-run               Do not send the config to Kubernetes
       -p, --from-project string   Retrieve the given project from Kubernetes and use it to set the default values.
       -x, --no-prompts            Do not prompt the user for input. Use this with -f to skip prompts.
       -o, --out string            File where configuration should be saved. The configuration is stored as a JSON Kubernetes Secret
       -r, --replace               Replace an existing project with this revised one. Use this to modify existing projects.

     Global Flags:
           --kube-context string   The name of the kubeconfig context to use.
           --kubeconfig string     The path to a KUBECONFIG file, overrides $KUBECONFIG.
       -n, --namespace string      The Kubernetes namespace for Brigade (default "default")
       -v, --verbose               Turn on verbose output

     secrets "brigade-6e35bd4c52f9e015cfe3308c2b19eba59990e1019beb499eadee67" already exists
   --
```