### PR TITLE
feat(*): support project and brigade.js overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ instance of the project and run real-world scenarios to verify behavior.
 To run tests, execute:
 
 ```console
-./test/run
+./test/run.sh
 ```
+
+Optionally, non-default values for `brigade.js` file location and project fixture can be provided:
+
+```console
+BRIGADE_JS=./path/to/brigade.js FIXTURE_PROJECT_NAME=my/test-fixture ./test/run.sh
+```
+
+If supplying your own `FIXTURE_PROJECT_NAME`, ensure it already exists before running tests.
 
 This script sets up a local minikube with the test project to execute tests
 against. These tests also run in

--- a/test/setup/setup_brigade.sh
+++ b/test/setup/setup_brigade.sh
@@ -4,7 +4,8 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BRIG_LOCATION="$SCRIPT_DIR"/../bin/brig
 BRIG_VERSION="v0.18.0"
-FIXTURE_PROJECT_NAME=blimmer/brigade-project-integration-test
+DEFAULT_PROJECT_FIXTURE="blimmer/brigade-project-integration-test"
+FIXTURE_PROJECT_NAME="${FIXTURE_PROJECT_NAME:-${DEFAULT_PROJECT_FIXTURE}}"
 
 check_helm() {
   if ! command -v helm; then
@@ -18,7 +19,7 @@ init_helm() {
 }
 
 install_brigade() {
-  helm repo add brigade https://azure.github.io/brigade
+  helm repo add brigade https://azure.github.io/brigade 
 
   if ! helm status brigade; then
     helm install -n brigade brigade/brigade --set rbac.enabled=true
@@ -45,7 +46,12 @@ install_brig_cli_tool() {
 
 setup_project() {
   if ! $BRIG_LOCATION project get $FIXTURE_PROJECT_NAME; then
-     $BRIG_LOCATION project create -x -f "$SCRIPT_DIR"/../fixtures/project-fixture.json
+    if [[ "${FIXTURE_PROJECT_NAME}" == "${DEFAULT_PROJECT_FIXTURE}" ]]; then
+      $BRIG_LOCATION project create -x -f "$SCRIPT_DIR"/../fixtures/project-fixture.json
+    else
+      echo "Project '${FIXTURE_PROJECT_NAME}' not known to Brigade. Please create before running tests."
+      exit 1
+    fi
   fi
 }
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -7,7 +7,9 @@ load "$BATS_TEST_DIRNAME/libs/bats-assert/load.bash"
 
 # Globals
 GIT_DIR="$BATS_TEST_DIRNAME/.."
-BRIG_RUN="$BATS_TEST_DIRNAME/bin/brig run -f $GIT_DIR/brigade.js blimmer/brigade-project-integration-test"
+BRIGADE_JS="${BRIGADE_JS:-$GIT_DIR/brigade.js}"
+FIXTURE_PROJECT_NAME="${FIXTURE_PROJECT_NAME:-blimmer/brigade-project-integration-test}"
+BRIG_RUN="$BATS_TEST_DIRNAME/bin/brig run -f $BRIGADE_JS $FIXTURE_PROJECT_NAME"
 
 # Begin Tests
 


### PR DESCRIPTION
This represents my quick adjustments to support testing against a non-default Brigade project and/or a non-default `brigade.js` file.  Certainly open to suggestions/feedback on implementation.  